### PR TITLE
Fix drive selection and add steam installer copy

### DIFF
--- a/build_installer.bat
+++ b/build_installer.bat
@@ -1,0 +1,2 @@
+@echo off
+pyinstaller --noconfirm --onefile --add-binary "steam.exe;." beta1installer.py

--- a/steam.exe
+++ b/steam.exe
@@ -1,0 +1,1 @@
+Dummy Steam executable


### PR DESCRIPTION
## Summary
- correct drive selection property so folder tree shows drive contents
- add `resource_path` helper for PyInstaller resource access
- implement real copy of `steam.exe` during install progress
- include `steam.exe` in build output via a `build_installer.bat`

## Testing
- `python -m py_compile beta1installer.py`

------
https://chatgpt.com/codex/tasks/task_e_685512bc652c83309b7cd5d780a39ff1